### PR TITLE
Fix to make image hashes match

### DIFF
--- a/iwata/pipelines.py
+++ b/iwata/pipelines.py
@@ -95,10 +95,10 @@ class MarkdownWriterPipeline(object):
             self.md += "\n\n"
 
         if "image" in item:
-            url = "https:"+ item["image"]
+            url = item["image"]
             hashed = hashlib.sha1(url.encode())
 #            self.md += "!["+ os.path.basename(item["image"]) +"]("+ item["image"] +")\n\n"        # online
-            self.md += "![https:"+ item["image"] +"](images/"+ hashed.hexdigest() +".jpg)\n\n"    # local
+            self.md += "!["+ item["image"] +"](images/"+ hashed.hexdigest() +".jpg)\n\n"    # local
 
         self.all_md += self.md
 


### PR DESCRIPTION
When generating the HTML/MD files none of the images worked, I noticed that the hashes in the HTML didn't actually match any of the hashed filenames in the images directory.  I suspected that these `https:` prefixes were creating distinct hashes that didn't match the actual image filenames, and sure enough removing them seems to have fixed the problem.

I can only speculate as to what these prefixes were accomplishing originally (they created urls like `https:https://www.etc`, maybe an older version of the EU Iwata Asks needed this and it's since been updated on their end) so if pulling them out doesn't actually make sense feel free to close this PR, but this fixed worked in my scenario!